### PR TITLE
Use systemctl to start tftp instead of xinetd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,7 @@ VOLUME [ “/sys/fs/cgroup” ]
 RUN yum -y install epel-release
 RUN yum -y install cobbler cobbler-web dhcp bind syslinux pykickstart
 
-RUN systemctl enable cobblerd httpd dhcpd
-
-# enable tftp
-RUN sed -i -e 's/\(^.*disable.*=\) yes/\1 no/' /etc/xinetd.d/tftp
-
-# create rsync file
-RUN touch /etc/xinetd.d/rsync
+RUN systemctl enable cobblerd httpd dhcpd tftp.socket
 
 EXPOSE 69
 EXPOSE 80


### PR DESCRIPTION
xinetd isn't running and as soon as you install it,
it messes up systemd.  The tested solution is to
use systemd to run tftp instead.